### PR TITLE
Cas authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,15 +11,16 @@ gem 'turbolinks'
 gem 'jbuilder', '~> 1.2'
 gem 'devise'
 gem 'omniauth-facebook'
-gem "omniauth-google-oauth2"
+gem 'omniauth-google-oauth2'
 gem 'omniauth-zooniverse', '~> 0.0.3'
+gem 'omniauth-cas'
 
 gem 'mongoid', '~> 5.1.0'
 gem 'active_model_serializers'
 gem 'mongoid-serializer'
 gem 'rack-cors', :require => 'rack/cors'
-gem "bson"
-gem "moped"
+gem 'bson'
+gem 'moped'
 gem 'sprockets-coffee-react'
 gem 'stylus', '~> 1.0.1'
 gem 'browserify-rails', '~> 0.9.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,10 @@ GEM
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
+    omniauth-cas (1.1.0)
+      addressable (~> 2.3)
+      nokogiri (~> 1.5)
+      omniauth (~> 1.2.0)
     omniauth-facebook (2.0.1)
       omniauth-oauth2 (~> 1.2)
     omniauth-google-oauth2 (0.2.6)
@@ -321,6 +325,7 @@ DEPENDENCIES
   moped
   newrelic_moped
   newrelic_rpm
+  omniauth-cas
   omniauth-facebook
   omniauth-google-oauth2
   omniauth-zooniverse (~> 0.0.3)

--- a/app/assets/javascripts/components/login.cjsx
+++ b/app/assets/javascripts/components/login.cjsx
@@ -50,7 +50,7 @@ Login = React.createClass
 
   renderLoginOptions: (label,classNames) ->
     links = @props.loginProviders.map (link) ->
-      icon_id = if link.id == 'zooniverse' then 'dot-circle-o' else link.id
+      icon_id = if link.id == 'zooniverse' then 'dot-circle-o' else if link.id == 'cas' then 'graduation-cap' else link.id
       <a key="login-link-#{link.id}" href={link.path} title="Log in using #{link.name}"><i className="fa fa-#{icon_id} fa-2" /></a>
 
     <span className={classNames}>

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -27,6 +27,15 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     success_redirect
   end
 
+  def cas
+    @user = User.find_for_oauth(request.env["omniauth.auth"], current_user)
+
+    if @user
+      sign_in(@user, :bypass => true)
+    end
+    success_redirect
+   end
+
   private
 
   def success_redirect

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User
          :recoverable, :rememberable, :trackable, :validatable
 
 
-  devise :omniauthable, :omniauth_providers => [:facebook,:google_oauth2,:zooniverse]
+  devise :omniauthable, :omniauth_providers => [:facebook,:google_oauth2,:zooniverse,:cas]
 
 
   ## Database authenticatable
@@ -141,6 +141,8 @@ class User
       details_from_google(access_token)
     when "zooniverse"
       details_from_zooniverse(access_token)
+    when "cas"
+      details_from_cas(access_token)
     end
   end
 
@@ -177,6 +179,14 @@ class User
       provider: access_token["provider"]
     }
   end
+
+  def self.details_from_cas(access_token)
+    {
+      name: access_token["uid"],
+      uid: access_token["uid"],
+      provider: access_token["provider"]
+    }
+  end
   
   def self.create_guest_user
     u = create({
@@ -199,6 +209,8 @@ class User
         { id: p, path: '/users/auth/google_oauth2', name: 'Google' }
       when 'zooniverse'
         { id: p, path: '/users/auth/zooniverse', name: 'Zooniverse' }
+      when 'cas'
+        { id: p, path: '/users/auth/cas', name: 'CAS' }
       end
     end
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -255,13 +255,24 @@ Devise.setup do |config|
   # When using omniauth, Devise cannot automatically set Omniauth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
+
   providers = YAML.load(ERB.new(File.read(Rails.root.join('config', 'login_providers.yml.erb'))).result)["providers"]
 
-  config.omniauth :zooniverse, providers["zooniverse"]["id"], providers["zooniverse"]["secret"] if providers["zooniverse"]
-  config.omniauth :google_oauth2, providers["google"]["id"], providers["google"]["secret"] if providers["google"]
   if providers["facebook"]
     # FB seems to require explicit info_fields w/email or else doesn't return email:
     config.omniauth :facebook, providers["facebook"]["id"], providers["facebook"]["secret"], info_fields: 'name,email'  
+  end
+
+  if providers["zooniverse"]
+    config.omniauth :zooniverse, providers["zooniverse"]["id"], providers["zooniverse"]["secret"] if providers["zooniverse"]
+  end
+
+  if providers["google"]
+    config.omniauth :google_oauth2, providers["google"]["id"], providers["google"]["secret"] if providers["google"]
+  end
+
+  if providers["cas"]
+    config.omniauth :cas, providers["cas"]["custom_auth_params"]
   end
 
 end

--- a/config/initializers/register_auth_options.rb
+++ b/config/initializers/register_auth_options.rb
@@ -5,6 +5,10 @@ Rails.application.config.before_initialize do
   providers.each do |k,v| 
     if ! v['id'].blank? && ! v['secret'].blank?
       provider_keys << k
+  
+    # whitelist cas authentication by virtue of its custom_auth_params
+    elsif ! v['custom_auth_params'].blank?
+      provider_keys << k
     end
   end
 

--- a/config/login_providers.yml.erb
+++ b/config/login_providers.yml.erb
@@ -10,3 +10,13 @@ providers:
   zooniverse:
     id: <%=ENV["ZOONIVERSE_ID"]%>
     secret: <%=ENV["ZOONIVERSE_SECRET"]%>
+
+  cas:
+    id: "some_id"
+    secret: "some_secret"
+    custom_auth_params:
+      host: 'secure.its.yale.edu'
+      ssl: true
+      login_url: '/cas/login'
+      logout_url: '/cas/logout'
+      service_validate_url: '/cas/serviceValidate'


### PR DESCRIPTION
This pull request adds CAS authentication as a login option to our installation of the scribeApi. The current icon for CAS authentication is a graduation cap because Scribe is configured to pull icons from FontAwesome, but we can use another icon of our choosing if that's preferable. Here's the current view for users who are not logged in with Google auth on the left and CAS on the right:

![not_logged_in](https://cloud.githubusercontent.com/assets/4801116/16272481/f08b715e-386b-11e6-9289-7a5d48a76c6e.png)

Here's the view for users authenticated via CAS:

![logged_in](https://cloud.githubusercontent.com/assets/4801116/16272507/0490fdb8-386c-11e6-8ceb-b5cb28912a29.png)

When a logged in user submits a POST request (e.g. within a Mark or Transcribe event) the client sends a consistent user id to the server. This user id persists across login/logout events as expected:

```{"find"=>"users", "filter"=>{"_id"=>BSON::ObjectId('576aa1c73dfe9ea13987984b')}, "limit"=>1, "singleBatch"=>true}```