### PR TITLE
add user-specific email identifier to all cas-authed users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -184,7 +184,8 @@ class User
     {
       name: access_token["uid"],
       uid: access_token["uid"],
-      provider: access_token["provider"]
+      provider: access_token["provider"],
+      email: access_token["uid"] + "@yale.edu"
     }
   end
   


### PR DESCRIPTION
CAS omniauth does not return user email addresses, but scribe requires an email in order to allow a user to authenticate. This is a placeholder method to allow users to authenticate with CAS for development purposes until we discuss how best to interact with a CAS identity endpoint that does return email addresses.