### PR TITLE
Twitter authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
 gem 'omniauth-zooniverse', '~> 0.0.3'
 gem 'omniauth-cas'
+gem 'omniauth-twitter'
 
 gem 'mongoid', '~> 5.1.0'
 gem 'active_model_serializers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,7 @@ GEM
     newrelic_rpm (3.13.2.302)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    oauth (0.5.1)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -190,11 +191,17 @@ GEM
     omniauth-google-oauth2 (0.2.6)
       omniauth (> 1.0)
       omniauth-oauth2 (~> 1.1)
+    omniauth-oauth (1.1.0)
+      oauth
+      omniauth (~> 1.0)
     omniauth-oauth2 (1.2.0)
       faraday (>= 0.8, < 0.10)
       multi_json (~> 1.3)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    omniauth-twitter (1.2.1)
+      json (~> 1.3)
+      omniauth-oauth (~> 1.1)
     omniauth-zooniverse (0.0.3)
     origin (2.2.0)
     orm_adapter (0.5.0)
@@ -328,6 +335,7 @@ DEPENDENCIES
   omniauth-cas
   omniauth-facebook
   omniauth-google-oauth2
+  omniauth-twitter
   omniauth-zooniverse (~> 0.0.3)
   pry
   puma (~> 2.14.0)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -27,6 +27,15 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     success_redirect
   end
 
+  def twitter
+   @user = User.find_for_oauth(request.env["omniauth.auth"], current_user)
+
+   if @user
+     sign_in(@user, :bypass => true)
+   end
+   success_redirect
+  end
+
   def cas
     @user = User.find_for_oauth(request.env["omniauth.auth"], current_user)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,18 +190,22 @@ class User
       name: access_token["uid"],
       uid: access_token["uid"],
       provider: access_token["provider"],
-      email: "sample@email.com"
+      email: access_token["uid"] + "@yale.edu"
     }
   end
 
   def self.details_from_twitter(access_token)
     info = access_token["info"]
+
+    # Try to retrieve the user's email address on twitter. 
+    # If that address is left blank, use a unique id
+    email = info["email"] ? info["email"] : access_token["uid"] + "@twitter.com"
     {
       name: info["name"],
       uid: access_token["uid"],
       provider: access_token["provider"],
       avatar: info["image"],
-      email: "douglas.duhaime@gmail.com"
+      email: email
     }
   end
   

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User
          :recoverable, :rememberable, :trackable, :validatable
 
 
-  devise :omniauthable, :omniauth_providers => [:facebook,:google_oauth2,:zooniverse,:cas]
+  devise :omniauthable, :omniauth_providers => [:facebook,:google_oauth2,:zooniverse,:cas,:twitter]
 
 
   ## Database authenticatable
@@ -124,8 +124,11 @@ class User
 
   def self.find_for_oauth(access_token, signed_in_resource=nil)
 
+    # If this user has authenticated with this auth provider and had the same uid,
+    # log them in as the already-saved user
     if user = self.find_by({provider: access_token[:provider], uid: access_token[:uid]})
       user
+
     else # Create a user with a stub password.
       details = details_from_oauth access_token[:provider], access_token
       tmp_pass = Devise.friendly_token[0,20]
@@ -143,6 +146,8 @@ class User
       details_from_zooniverse(access_token)
     when "cas"
       details_from_cas(access_token)
+    when "twitter"
+      details_from_twitter(access_token)
     end
   end
 
@@ -184,7 +189,19 @@ class User
     {
       name: access_token["uid"],
       uid: access_token["uid"],
-      provider: access_token["provider"]
+      provider: access_token["provider"],
+      email: "sample@email.com"
+    }
+  end
+
+  def self.details_from_twitter(access_token)
+    info = access_token["info"]
+    {
+      name: info["name"],
+      uid: access_token["uid"],
+      provider: access_token["provider"],
+      avatar: info["image"],
+      email: "douglas.duhaime@gmail.com"
     }
   end
   
@@ -211,6 +228,8 @@ class User
         { id: p, path: '/users/auth/zooniverse', name: 'Zooniverse' }
       when 'cas'
         { id: p, path: '/users/auth/cas', name: 'CAS' }
+      when 'twitter'
+        { id: p, path: '/users/auth/twitter', name: 'Twitter' }
       end
     end
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -275,4 +275,8 @@ Devise.setup do |config|
     config.omniauth :cas, providers["cas"]["custom_auth_params"]
   end
 
+  if providers["twitter"]
+    config.omniauth :twitter, providers["twitter"]["id"], providers["twitter"]["secret"] if providers["twitter"]
+  end
+
 end

--- a/config/login_providers.yml.erb
+++ b/config/login_providers.yml.erb
@@ -20,3 +20,7 @@ providers:
       login_url: '/cas/login'
       logout_url: '/cas/logout'
       service_validate_url: '/cas/serviceValidate'
+
+  twitter:
+    id: <%=ENV["TWITTER_KEY"]%>
+    secret: <%=ENV["TWITTER_SECRET"]%>


### PR DESCRIPTION
This branch introduces Twitter as an auth option. I wrote this out to investigate #11, as I needed multiple auth providers for which I had registered the same email address to debug that story. 

This branch helped me realize that we'll probably want to consider the optimal way to handle primary keys for users. Right now email serves this purpose, but neither CAS nor Twitter return email addresses in their responses, and a single user might well have different email addresses hooked up to different auth providers. The chief value in thinking the primary key question through is the ability to dedupe users (e.g. Bob uses CAS and Gmail to authenticate, and we'd like to know he's the same person during both sessions), though this may prove intractable if different omniauth servers return metadata fields that can't be deduped... 