### PR TITLE
Multiple authentication providers one email

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -10,28 +10,49 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def zooniverse
-   @user = User.find_for_oauth(request.env["omniauth.auth"], current_user)
-
-   if @user
-     sign_in(@user, :bypass => true)
-   end
-   success_redirect
-  end
-
-  def google_oauth2
     @user = User.find_for_oauth(request.env["omniauth.auth"], current_user)
 
     if @user
-      sign_in(@user, :bypass => true)
+     sign_in(@user, :bypass => true)
     end
     success_redirect
   end
 
-  def cas
-    @user = User.find_for_oauth(request.env["omniauth.auth"], current_user)
+  def google_oauth2
+    omniauth_hash = request.env["omniauth.auth"]
+    google_email = omniauth_hash[:extra][:raw_info][:email]
+
+    @user = User.find_for_oauth(omniauth_hash, current_user, google_email)
 
     if @user
       sign_in(@user, :bypass => true)
+      @user.update_attribute(:sign_in_count, @user.sign_in_count + 1)
+    end
+    success_redirect
+  end
+
+  def twitter
+    omniauth_hash = request.env["omniauth.auth"]
+    info = omniauth_hash["info"]
+    twitter_email = info["email"] ? info["email"] : omniauth_hash["uid"] + "@twitter.com"
+
+    @user = User.find_for_oauth(omniauth_hash, current_user, twitter_email)
+
+    if @user
+      sign_in(@user, :bypass => true)
+      @user.update_attribute(:sign_in_count, @user.sign_in_count + 1)
+    end
+   success_redirect
+  end
+
+  def cas
+    omniauth_hash = request.env["omniauth.auth"]
+    cas_email = omniauth_hash["uid"] + "@yale.edu"
+    @user = User.find_for_oauth(omniauth_hash, current_user, cas_email)
+
+    if @user
+      sign_in(@user, :bypass => true)
+      @user.update_attribute(:sign_in_count, @user.sign_in_count + 1)
     end
     success_redirect
    end


### PR DESCRIPTION
This pull request allows users to authenticate with multiple auth providers that have the same email address. It also increments the sign in count of users upon login. Both of these methods are configured for Twitter, CAS, and Google auth providers. 

Closes #11 Closes #6